### PR TITLE
Restructure the design of the gem, and introduce the message api

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,33 +25,75 @@ Or install it yourself as:
 Log in to your [BotMetrics](https://getbotmetrics.com) account, navigate
 to "Bot Settings" and find out your Bot ID and API Key.
 
-Set the following environment variables with the Bot ID and API Key respectively.
-
-```
-BOTMETRICS_BOT_ID=your-bot-id
-BOTMETRICS_API_KEY=your-api-key
-```
-
-Once you have that set up, every time you create a new Slack Bot (in the
-OAuth2 callback), and assuming the bot token you received as part of the
-OAuth2 callback is `bot-token`, make the following call:
+With that, you can initialize a `BotMetrics::Client`:
 
 ```ruby
-BotMetrics.register_bot!('bot-token')
+client = BotMetrics::Client.new(api_key: '123', bot_id: '123')
 ```
 
-### Retroactive Registration
+### `register_bot!`
+
+With a `BotMetrics::Client` instance,
+every time you create a new Slack Bot (in the OAuth2 callback),
+and assuming the bot token you received as part of the OAuth2 callback is `bot-token`,
+you can make the following call:
+
+```ruby
+client = BotMetrics::Client.new(api_key: '123', bot_id: '123')
+client.register_bot!('bot-token')
+```
+
+#### Retroactive Registration
 
 If you created your bot in the past, you can pass in `created_at` with
 the UNIX timestamp of when your bot was created, like so:
 
 ```ruby
-BotMetrics.register_bot!('bot-token', created_at: 1462318092)
+client = BotMetrics::Client.new(api_key: '123', bot_id: '123')
+client.register_bot!('bot-token', created_at: 1462318092)
 ```
+
+### `message`
+
+You can send messages to a Slack channel or user using the `#message` method:
+
+#### Sending a Message to a Channel
+
+```ruby
+client = BotMetrics::Client.new(api_key: '123', bot_id: '123')
+client.message(team_id: 'T123', channel: 'C123', text: 'Hello!')
+```
+
+#### Sending an Attachment to a User
+
+```ruby
+client = BotMetrics::Client.new(api_key: '123', bot_id: '123')
+client.message(
+  team_id: 'T123',
+  user: 'U123',
+  attachments:
+    [
+      {
+          "title": "Title",
+          "pretext": "Pretext _supports_ mrkdwn",
+          "text": "Testing *right now!*",
+          "mrkdwn_in": ["text", "pretext"]
+      }
+    ]
+)
+```
+
+Accepted parameters include:
+
+- `team_id`: This is the Slack ID
+- `channel`: This is the Slack channel's UID
+- `user`: This is the Slack user's UID
+- `text`: A string
+- `attachments`: Attachments that follows the Slack's [message attachment structure](https://api.slack.com/docs/attachments)
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment with the gem.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
@@ -63,4 +105,3 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/[USERN
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
-

--- a/README.md
+++ b/README.md
@@ -31,6 +31,18 @@ With that, you can initialize a `BotMetrics::Client`:
 client = BotMetrics::Client.new(api_key: '123', bot_id: '123')
 ```
 
+Alternatively, you can set the following ENV variables
+
+- `ENV['BOTMETRICS_API_KEY']` 
+- `ENV['BOTMETRICS_BOT_ID']`  
+- `ENV['BOTMETRICS_API_HOST']`
+
+and initialize a `BotMetrics::Client` with the default ENV variables:
+
+```ruby
+client = BotMetrics::Client.new
+```
+
 ### `register_bot!`
 
 With a `BotMetrics::Client` instance,

--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require "bundler/setup"
-require "botmetrics/rb"
+require_relative "../lib/botmetrics"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/botmetrics-rb.gemspec
+++ b/botmetrics-rb.gemspec
@@ -1,7 +1,7 @@
 # coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'botmetrics'
+require 'botmetrics-rb/version'
 
 Gem::Specification.new do |spec|
   spec.name          = "botmetrics-rb"

--- a/botmetrics-rb.gemspec
+++ b/botmetrics-rb.gemspec
@@ -27,8 +27,8 @@ Gem::Specification.new do |spec|
   spec.executables   = []
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "json",         "~> 1.8.3"
-  spec.add_dependency "excon",        "~> 0.49.0"
+  spec.add_dependency "json", "~> 1.8.3"
+  spec.add_dependency "http", "~> 2.0.0"
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/botmetrics-rb/version.rb
+++ b/lib/botmetrics-rb/version.rb
@@ -1,0 +1,3 @@
+module BotMetrics
+  VERSION = "0.0.3"
+end

--- a/lib/botmetrics.rb
+++ b/lib/botmetrics.rb
@@ -30,6 +30,20 @@ module BotMetrics
       response.code == 201
     end
 
+    def message(team_id:, channel: nil, user: nil, text: nil, attachments: nil)
+      params = {
+        "message[team_id]"     => team_id,
+        "message[channel]"     => channel,
+        "message[user]"        => user,
+        "message[text]"        => text,
+        "message[attachments]" => attachments
+      }.delete_if { |_, v| v.nil? }
+
+      response = HTTP.auth(api_key).post("#{api_url}/messages", params: params)
+
+      response.code == 202
+    end
+
     private
 
       attr_accessor :api_key, :bot_id, :api_host

--- a/lib/botmetrics.rb
+++ b/lib/botmetrics.rb
@@ -36,7 +36,7 @@ module BotMetrics
         "message[channel]"     => channel,
         "message[user]"        => user,
         "message[text]"        => text,
-        "message[attachments]" => attachments
+        "message[attachments]" => attachments.nil? ? nil : attachments.to_json
       }.delete_if { |_, v| v.nil? }
 
       response = HTTP.auth(api_key).post("#{api_url}/messages", params: params)

--- a/lib/botmetrics.rb
+++ b/lib/botmetrics.rb
@@ -36,7 +36,7 @@ module BotMetrics
         "message[channel]"     => channel,
         "message[user]"        => user,
         "message[text]"        => text,
-        "message[attachments]" => attachments.nil? ? nil : attachments.to_json
+        "message[attachments]" => message_attachments(attachments)
       }.delete_if { |_, v| v.nil? }
 
       response = HTTP.auth(api_key).post("#{api_url}/messages", params: params)
@@ -61,6 +61,18 @@ module BotMetrics
           read_timeout: 360,
           connect_timeout: 360
         }.merge(extra_params)
+      end
+
+      def message_attachments(attachments)
+        if attachments.nil?
+          nil
+        else
+          if attachments.is_a? String
+            attachments
+          else
+            attachments.to_json
+          end
+        end
       end
   end
 end

--- a/lib/botmetrics.rb
+++ b/lib/botmetrics.rb
@@ -5,18 +5,18 @@ module BotMetrics
   class Client
     DEFAULT_API_HOST = "https://www.getbotmetrics.com".freeze
 
-    def initialize(api_key:, bot_id:, api_host: nil)
-      if blank?(api_key)
+    def initialize(api_key: nil, bot_id: nil, api_host: nil)
+      @api_key  = api_key  || ENV['BOTMETRICS_API_KEY']
+      @bot_id   = bot_id   || ENV['BOTMETRICS_BOT_ID']
+      @api_host = api_host || ENV['BOTMETRICS_API_HOST'] || DEFAULT_API_HOST
+
+      if blank?(@api_key)
         raise ArgumentError.new("Missing argument api_key. Please pass api_key in as an argument.")
       end
 
-      if blank?(bot_id)
+      if blank?(@bot_id)
         raise ArgumentError.new("Missing argument bot_id. Please pass bot_id in as an argument.")
       end
-
-      @api_key  = api_key
-      @bot_id   = bot_id
-      @api_host = api_host || DEFAULT_API_HOST
     end
 
     def register_bot!(token, opts = {})

--- a/lib/botmetrics.rb
+++ b/lib/botmetrics.rb
@@ -1,5 +1,5 @@
 require "json"
-require "excon"
+require "http"
 
 module BotMetrics
   class Client
@@ -20,15 +20,14 @@ module BotMetrics
     end
 
     def register_bot!(token, opts = {})
-      params = { "instance[token]" => token, "format" => "json" }
+      params = { "format" => "json", "instance[token]" => token }
 
       created_at = opts[:created_at] || opts["created_at"]
       params["instance[created_at]"] = created_at.to_i if created_at.to_i != 0
 
-      connection = Excon.new("#{api_url}/instances", options(body: URI.encode_www_form(params)))
-      response = connection.request(method: :post)
+      response = HTTP.auth(api_key).post("#{api_url}/instances", params: params)
 
-      response.status == 201
+      response.code == 201
     end
 
     private
@@ -50,5 +49,4 @@ module BotMetrics
         }.merge(extra_params)
       end
   end
-
 end

--- a/lib/botmetrics.rb
+++ b/lib/botmetrics.rb
@@ -6,11 +6,11 @@ module BotMetrics
     DEFAULT_API_HOST = "https://www.getbotmetrics.com".freeze
 
     def initialize(api_key:, bot_id:, api_host: nil)
-      if api_key.nil? || api_key == ""
+      if blank?(api_key)
         raise ArgumentError.new("Missing argument api_key. Please pass api_key in as an argument.")
       end
 
-      if bot_id.nil? || bot_id == ""
+      if blank?(bot_id)
         raise ArgumentError.new("Missing argument bot_id. Please pass bot_id in as an argument.")
       end
 
@@ -31,6 +31,14 @@ module BotMetrics
     end
 
     def message(team_id:, channel: nil, user: nil, text: nil, attachments: nil)
+      if blank?(channel) && blank?(user)
+        raise ArgumentError.new("Missing argument channel and user. Please provide at least one.")
+      end
+
+      if blank?(text) && blank?(attachments)
+        raise ArgumentError.new("Missing argument text and attachments. Please provide at least one.")
+      end
+
       params = {
         "message[team_id]"     => team_id,
         "message[channel]"     => channel,
@@ -47,6 +55,10 @@ module BotMetrics
     private
 
       attr_accessor :api_key, :bot_id, :api_host
+
+      def blank?(attr)
+        attr.nil? || attr == ''
+      end
 
       def api_url
         "#{api_host}/bots/#{bot_id}"

--- a/spec/botmetrics/botmetrics_spec.rb
+++ b/spec/botmetrics/botmetrics_spec.rb
@@ -95,5 +95,19 @@ describe BotMetrics do
 
       it { expect(client.message(team_id: 'T123', user: 'U123', attachments: [{ pretext: 'Hi!', title: 'Hello!' }].to_json)).to be_truthy }
     end
+
+    context 'failures' do
+      it 'raises error when both channel and user are blank' do
+        expect {
+          client.message(team_id: 'T123', text: 'Hello!')
+        }.to raise_error("Missing argument channel and user. Please provide at least one.")
+      end
+
+      it 'raises error when both text and attachments are blank' do
+        expect {
+          client.message(team_id: 'T123', user: 'U123')
+        }.to raise_error("Missing argument text and attachments. Please provide at least one.")
+      end
+    end
   end
 end

--- a/spec/botmetrics/botmetrics_spec.rb
+++ b/spec/botmetrics/botmetrics_spec.rb
@@ -62,4 +62,16 @@ describe BotMetrics do
       it { expect(client.register_bot!('bot_token')).to be_truthy }
     end
   end
+
+  describe '#message' do
+    let(:client) { BotMetrics::Client.new(api_key: 'api_key', bot_id: 'bot_id') }
+
+    before do
+      stub_request(:post, "https://www.getbotmetrics.com/bots/bot_id/messages?message%5Bteam_id%5D=T123&message%5Buser%5D=U123&message%5Btext%5D=Text").
+        with(headers: { "Authorization" => 'api_key' }).
+        to_return(body: "{\"id\":1}", status: 202)
+    end
+
+    it { expect(client.message(team_id: 'T123', user: 'U123', text: 'Text')).to be_truthy }
+  end
 end

--- a/spec/botmetrics/botmetrics_spec.rb
+++ b/spec/botmetrics/botmetrics_spec.rb
@@ -76,7 +76,7 @@ describe BotMetrics do
       it { expect(client.message(team_id: 'T123', user: 'U123', text: 'Text')).to be_truthy }
     end
 
-    context 'message with text' do
+    context 'message with attachments as non string' do
       before do
         stub_request(:post, "https://www.getbotmetrics.com/bots/bot_id/messages?message%5Battachments%5D=%5B%7B%22pretext%22:%22Hi!%22,%22title%22:%22Hello!%22%7D%5D&message%5Bteam_id%5D=T123&message%5Buser%5D=U123").
           with(:headers => { 'Authorization'=>'api_key' }).
@@ -84,6 +84,16 @@ describe BotMetrics do
       end
 
       it { expect(client.message(team_id: 'T123', user: 'U123', attachments: [{ pretext: 'Hi!', title: 'Hello!' }])).to be_truthy }
+    end
+
+    context 'message with attachments as string' do
+      before do
+        stub_request(:post, "https://www.getbotmetrics.com/bots/bot_id/messages?message%5Battachments%5D=%5B%7B%22pretext%22:%22Hi!%22,%22title%22:%22Hello!%22%7D%5D&message%5Bteam_id%5D=T123&message%5Buser%5D=U123").
+          with(:headers => { 'Authorization'=>'api_key' }).
+          to_return(status: 202)
+      end
+
+      it { expect(client.message(team_id: 'T123', user: 'U123', attachments: [{ pretext: 'Hi!', title: 'Hello!' }].to_json)).to be_truthy }
     end
   end
 end

--- a/spec/botmetrics/botmetrics_spec.rb
+++ b/spec/botmetrics/botmetrics_spec.rb
@@ -2,19 +2,50 @@ require 'spec_helper'
 
 describe BotMetrics do
   describe '#initialize' do
-    context 'when api key is not set' do
-      it 'raises an error' do
-        expect {
-          BotMetrics::Client.new(api_key: nil, bot_id: 'bot_id')
-        }.to raise_error("Missing argument api_key. Please pass api_key in as an argument.")
+    context 'without ENV variables' do
+      context 'when api_key is not set' do
+        it 'raises an error' do
+          expect {
+            BotMetrics::Client.new(api_key: nil, bot_id: 'bot_id')
+          }.to raise_error("Missing argument api_key. Please pass api_key in as an argument.")
+        end
+      end
+
+      context 'when bot_id is not set' do
+        it 'raises an error' do
+          expect {
+            BotMetrics::Client.new(api_key: 'api_key', bot_id: nil)
+          }.to raise_error("Missing argument bot_id. Please pass bot_id in as an argument.")
+        end
+      end
+
+      context 'when api_key and bot_id are set' do
+        it 'works' do
+          client = BotMetrics::Client.new(api_key: 'api_key', bot_id: 'bot_id')
+          expect(client.instance_variable_get(:@api_key)).to eq 'api_key'
+          expect(client.instance_variable_get(:@bot_id)).to eq 'bot_id'
+        end
       end
     end
 
-    context 'when bot id is not set' do
-      it 'raises an error' do
-        expect {
-          BotMetrics::Client.new(api_key: 'api_key', bot_id: nil)
-        }.to raise_error("Missing argument bot_id. Please pass bot_id in as an argument.")
+    context 'with ENV variables' do
+      before do
+        ENV['BOTMETRICS_API_KEY']  = 'api_key'
+        ENV['BOTMETRICS_BOT_ID']   = 'bot_id'
+        ENV['BOTMETRICS_API_HOST'] = 'api_host'
+      end
+
+      after do
+        ENV['BOTMETRICS_API_KEY']  = nil
+        ENV['BOTMETRICS_BOT_ID']   = nil
+        ENV['BOTMETRICS_API_HOST'] = nil
+      end
+
+      it 'defaults to ENV' do
+        client = BotMetrics::Client.new
+        expect(client.instance_variable_get(:@api_key)).to eq 'api_key'
+        expect(client.instance_variable_get(:@bot_id)).to eq 'bot_id'
+        expect(client.instance_variable_get(:@api_host)).to eq 'api_host'
       end
     end
   end

--- a/spec/botmetrics/botmetrics_spec.rb
+++ b/spec/botmetrics/botmetrics_spec.rb
@@ -24,9 +24,8 @@ describe BotMetrics do
       let(:client) { BotMetrics::Client.new(api_key: 'api_key', bot_id: 'bot_id') }
 
       before do
-        stub_request(:post, "https://www.getbotmetrics.com/bots/bot_id/instances").
-          with(body:    "instance%5Btoken%5D=bot_token&format=json",
-               headers: { "Authorization" => 'api_key' }).
+        stub_request(:post, "https://www.getbotmetrics.com/bots/bot_id/instances?instance%5Btoken%5D=bot_token&format=json").
+          with(headers: { "Authorization" => 'api_key' }).
           to_return(body: "{\"id\":1}", status: 201)
       end
 
@@ -36,9 +35,11 @@ describe BotMetrics do
         before do
           @now = Time.now
 
-          stub_request(:post, "https://www.getbotmetrics.com/bots/bot_id/instances").
-            with(body:    "instance%5Btoken%5D=bot_token&format=json&instance%5Bcreated_at%5D=#{@now.to_i}",
-                 headers: { "Authorization" => 'api_key' }).
+          stub_request(
+            :post,
+            "https://www.getbotmetrics.com/bots/bot_id/instances?instance%5Btoken%5D=bot_token&format=json&instance%5Bcreated_at%5D=#{@now.to_i}"
+          ).
+            with(headers: { "Authorization" => 'api_key' }).
             to_return(body: "{\"id\":1}", status: 201)
         end
 
@@ -50,9 +51,11 @@ describe BotMetrics do
       let(:client) { BotMetrics::Client.new(api_key: 'api_key', bot_id: 'bot_id', api_host: 'http://localhost:5000') }
 
       before do
-        stub_request(:post, "http://localhost:5000/bots/bot_id/instances").
-          with(body:    "instance%5Btoken%5D=bot_token&format=json",
-               headers: { "Authorization" => 'api_key' }).
+        stub_request(
+          :post,
+          "http://localhost:5000/bots/bot_id/instances?instance%5Btoken%5D=bot_token&format=json"
+        ).
+          with(headers: { "Authorization" => 'api_key' }).
           to_return(body: "{\"id\":1}", status: 201)
       end
 

--- a/spec/botmetrics/botmetrics_spec.rb
+++ b/spec/botmetrics/botmetrics_spec.rb
@@ -66,12 +66,24 @@ describe BotMetrics do
   describe '#message' do
     let(:client) { BotMetrics::Client.new(api_key: 'api_key', bot_id: 'bot_id') }
 
-    before do
-      stub_request(:post, "https://www.getbotmetrics.com/bots/bot_id/messages?message%5Bteam_id%5D=T123&message%5Buser%5D=U123&message%5Btext%5D=Text").
-        with(headers: { "Authorization" => 'api_key' }).
-        to_return(body: "{\"id\":1}", status: 202)
+    context 'message with text' do
+      before do
+        stub_request(:post, "https://www.getbotmetrics.com/bots/bot_id/messages?message%5Bteam_id%5D=T123&message%5Buser%5D=U123&message%5Btext%5D=Text").
+          with(headers: { "Authorization" => 'api_key' }).
+          to_return(status: 202)
+      end
+
+      it { expect(client.message(team_id: 'T123', user: 'U123', text: 'Text')).to be_truthy }
     end
 
-    it { expect(client.message(team_id: 'T123', user: 'U123', text: 'Text')).to be_truthy }
+    context 'message with text' do
+      before do
+        stub_request(:post, "https://www.getbotmetrics.com/bots/bot_id/messages?message%5Battachments%5D=%5B%7B%22pretext%22:%22Hi!%22,%22title%22:%22Hello!%22%7D%5D&message%5Bteam_id%5D=T123&message%5Buser%5D=U123").
+          with(:headers => { 'Authorization'=>'api_key' }).
+          to_return(status: 202)
+      end
+
+      it { expect(client.message(team_id: 'T123', user: 'U123', attachments: [{ pretext: 'Hi!', title: 'Hello!' }])).to be_truthy }
+    end
   end
 end


### PR DESCRIPTION
@arunthampi I did a redesign of the gem internals and the gem's api has changed as a result.

To use this gem, for example, you have to do it like so:

```
client = BotMetrics::Client.new(api_key: '123', bot_id: '123') 
# api_host is optional
client.register_bot!(token)
```

Let me know if this api works for you?

But with the change, I have also refactored the internals, so that it's much easier to add a new api call in the future.

Notably, I took out the `excon` gem and replaced it with `httprb` as the latter is supposed to be faster. (A side effect of this though is that [it doesn't work with webrick](http://stackoverflow.com/questions/2651379/webrickhttpstatuslengthrequired-error-when-accessing-create-method-in-contro), so I'll be issuing a PR to the main repo to get that dev server to start with passenger, like production, instead of webrick)

I also fixed `bin/console` as a result of changing the file structure, updated gemspec and readme (new readme [here](https://github.com/jollygoodcode/botmetrics-rb/blob/12dc91a901fdd0a44d4f34b345dde289032c228f/README.md)), and finally introduce the `#message` method.

👀  🙇 
